### PR TITLE
Fix stream types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "UPGRADING.md"
   ],
   "dependencies": {
+    "@types/readable-stream": "^4.0.18",
     "readable-stream": "^4.6.0"
   },
   "peerDependencies": {
@@ -30,7 +31,6 @@
     }
   },
   "devDependencies": {
-    "@types/readable-stream": "^4.0.18",
     "@voxpelli/tsconfig": "^15.1.0",
     "airtap": "^5.0.0",
     "airtap-playwright": "^1.0.1",


### PR DESCRIPTION
by including `@types/readable-stream` to non-dev dependencies.

Without it, a package installing `level-read-stream` without its dev dependencies gets type errors such as "Property 'on' does not exist on type 'KeyStream'"